### PR TITLE
Fix computer_name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ resource "azurerm_virtual_machine" "main" {
   }
 
   os_profile {
-    computer_name  = "${var.prefix}-vm1"
+    computer_name  = "${var.prefix}"
     admin_username = "${var.prefix}-user"
     admin_password = var.password != "" ? var.password : random_string.password.result
   }


### PR DESCRIPTION
Windows computer name cannot be more than 15 characters long, be entirely numeric, or contain the following characters: ` ~ ! @ # $ % ^ & * ( ) = + _ [ ] { } \\ | ; : . ' \" , < > / ?." Target="computerName"